### PR TITLE
Fix/feedback

### DIFF
--- a/app/src/main/java/com/nbc/curtaincall/presentation/search/SearchFragment.kt
+++ b/app/src/main/java/com/nbc/curtaincall/presentation/search/SearchFragment.kt
@@ -123,13 +123,6 @@ class SearchFragment : Fragment(), PosterClickListener {
                 }
             }
 
-            // 통신 장애시 안내 문구
-            searchViewModel.failureMessage.observe(viewLifecycleOwner) {
-                if (!it.isNullOrEmpty()) {
-                    Toast.makeText(requireContext(),it,Toast.LENGTH_SHORT).show()
-                }
-
-            }
 
             // 검색 리스트 구독하여 변경점 생기면, listadapter가 확인하여 리사이클러뷰 업데이트 , 검색결과 안내 text visible 유무
             searchViewModel.searchResultList.observe(viewLifecycleOwner) { result ->

--- a/app/src/main/res/layout/constraint_layout_search_rv.xml
+++ b/app/src/main/res/layout/constraint_layout_search_rv.xml
@@ -19,7 +19,8 @@
     <TextView
         android:id="@+id/tv_searchitem_genre"
         style="@style/posterTopLabel"
-        android:layout_height="25dp"
+        android:layout_height="20dp"
+        android:layout_marginStart="1dp"
         android:text="@string/filter_genre"
         app:layout_constraintStart_toStartOf="@+id/iv_search_result"
         app:layout_constraintTop_toTopOf="@+id/iv_search_result" />

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -14,6 +14,7 @@
         android:layout_marginTop="20dp"
         android:background="@drawable/shape_search_radius"
         android:hint="@string/input_search"
+        android:textSize="16sp"
         android:inputType="text|textAutoCorrect"
         android:paddingStart="20dp"
         android:singleLine="true"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -30,7 +30,8 @@
         <item name="android:textColor">@color/white</item>
         <item name="android:textSize">8sp</item>
         <item name="android:textStyle">bold</item>
-        <item name="android:layout_width">40dp</item>
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:paddingHorizontal">5dp</item>
     </style>
 
     <!--search filter bottom sheet close ic design-->


### PR DESCRIPTION
피드백 받은 부분중 일부 수정했습니다.

- 검색화면 검색창의 글자 크기 줄였습니다.
- 서버 통신 장애시 띄우던 토스트 메세지 삭제했습니다.
- 검색화면 아이템의 포스터 상단 뱃지 크기를 wrap_content로 너비 변경하여 맞췄습니다. (글자 안잘리도록)